### PR TITLE
restrction of waypoints parameters to avoid crash

### DIFF
--- a/autocar_nav/nodes/globalplanner.py
+++ b/autocar_nav/nodes/globalplanner.py
@@ -47,7 +47,11 @@ class GlobalPathPlanner(Node):
 
         except:
             raise Exception("Missing ROS parameters. Check the configuration file.")
-
+        if self.wp_ahead < 0 or self.wp_behind < 0 or self.wp_ahead+self.wp_behind < 2:
+            self.wp_ahead = 3
+            self.wp_behind = 3
+            self.get_logger().info('invalid values for waypoints selection, both of the ahead and behind waypoints should not be negative and 
+                                   the sum should be larger than 2, set both to default value 3.')
         # Get path to waypoints.csv
         dir_path = os.path.join(get_package_share_directory('autocar_nav'), 'data', 'waypoints.csv')
         df = pd.read_csv(dir_path)


### PR DESCRIPTION
Hi! I'm a researcher on bug detection and software robustness focusing on robotic applications. It's our new idea to design a language-irrelevant algorithm, so we are trying to check and fix some python-based programs to prove our algorithm. Since your program is one of the best opensource codes in python for the ROS system, we did a test and found some crashes:

```
local_planner:
Traceback (most recent call last):
  ...
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 86, in goals_cb
    self.publish_path()
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 101, in publish_path
    cx, cy, cyaw, _ = generate_cubic_path(self.ax, self.ay, self.ds)
  File "/home/r1/autoCar/install/autocar_nav/lib/python3.8/site-packages/autocar_nav/cubic_spline_interpolator.py", line 154, in generate_cubic_path
    sp2d = Spline2D(x, y)
  File "/home/r1/autoCar/install/autocar_nav/lib/python3.8/site-packages/autocar_nav/cubic_spline_interpolator.py", line 112, in __init__
    self.sx = Spline(self.s, x)
  File "/home/r1/autoCar/install/autocar_nav/lib/python3.8/site-packages/autocar_nav/cubic_spline_interpolator.py", line 19, in __init__
    A = self.matrixA(h, dim_size)
  File "/home/r1/autoCar/install/autocar_nav/lib/python3.8/site-packages/autocar_nav/cubic_spline_interpolator.py", line 39, in matrixA
    A[0, 1] = 0.0
IndexError: index 1 is out of bounds for axis 1 with size 1
```

It's because of a misconfiguration of waypoints_ahead and waypoints_behind in global_planner. The sum of them must be larger than or equal to 2, make A[0, 1] exists. For the users without a knowledge about this,  the value may be set to zero etc. 
Although it may be hard to happen in a project just used as a simple template we hope it can be addressed as a robust feature.