### PR TITLE
update_frequency restriction to avoid crash

### DIFF
--- a/autocar_nav/nodes/localplanner.py
+++ b/autocar_nav/nodes/localplanner.py
@@ -48,7 +48,9 @@ class LocalPathPlanner(Node):
 
         except:
             raise Exception("Missing ROS parameters. Check the configuration file.")
-
+        if self.frequency <= 0:
+            self.frequency = 10.0
+            self.get_logger().info('invalid value for update_frequency, which should be larger than zero, set it to default value 10.0 hz.')
         # Class constants
         self.ds = 1 / self.frequency
 

--- a/autocar_nav/nodes/tracker.py
+++ b/autocar_nav/nodes/tracker.py
@@ -50,7 +50,9 @@ class PathTracker(Node):
         
         except ValueError:
             raise Exception("Missing ROS parameters. Check the configuration file.")
-
+        if self.frequency <= 0:
+            self.frequency = 50.0
+            self.get_logger().info('invalid value for update_frequency, which should be larger than zero, set it to default value 50.0 hz.')
         # Class variables to use whenever within the class when necessary
         self.x = None
         self.y = None


### PR DESCRIPTION
Hi! I'm a researcher on bug detection and software robustness focusing on robotic applications. There 's another crash we found:

```
Traceback (most recent call last):
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 142, in main
    local_planner = LocalPathPlanner()
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 65, in __init__
    self.timer = self.create_timer(self.ds, self.timer_cb)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/node.py", line 1343, in create_timer
    timer = Timer(callback, callback_group, timer_period_nsec, clock, context=self.context)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/timer.py", line 30, in __init__
    self.__handle = Handle(_rclpy.rclpy_create_timer(
_rclpy.RCLError: Failed to create timer: timer period must be non-negative, at /tmp/binarydeb/ros-foxy-rcl-1.1.11/src/rcl/timer.c:139

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 152, in <module>
    main()
  File "/home/r1/autoCar/install/autocar_nav/lib/autocar_nav/localplanner.py", line 148, in main
    local_planner.destroy_node()
UnboundLocalError: local variable 'local_planner' referenced before assignment
```

It's because of a misconfiguration of update_frequency in global_planner. The value should be non-negative for the setting of timer. 
Although it may be hard to happen in a project just used as a simple template, we hope it can be addressed as a robust feature.

In addition. path_tracker.py has the same problem, we also change it.